### PR TITLE
feat(#10): Add more informative messages for warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ public class UserTest {
 }
 ```
 
-The next names will be considered as invalid:
+The next cases will be considered as invalid:
 
 ```java
 public class UserTest {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
   <artifactId>test-naming-conventions</artifactId>
-  <version>0.1.5-SNAPSHOT</version>
+  <version>0.1.6</version>
   <packaging>maven-plugin</packaging>
   <description>Plugin for checking test naming rules</description>
   <name>test-naming-conventions</name>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.24</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>3.8.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
   <artifactId>test-naming-conventions</artifactId>
-  <version>0.1.5</version>
+  <version>0.1.5-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <description>Plugin for checking test naming rules</description>
   <name>test-naming-conventions</name>

--- a/src/main/java/com/github/lombrozo/testnames/Cases.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cases.java
@@ -1,0 +1,24 @@
+package com.github.lombrozo.testnames;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@FunctionalInterface
+public interface Cases {
+
+    Collection<TestCase> all();
+
+    static Cases correct() {
+        return () -> Arrays.asList(
+            new TestCase.FakeCase("removes"),
+            new TestCase.FakeCase("creates")
+        );
+    }
+
+    static Cases wrong(){
+        return () -> Arrays.asList(
+            new TestCase.FakeCase("remove"),
+            new TestCase.FakeCase("test")
+        );
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/JavaParserCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/JavaParserCase.java
@@ -1,0 +1,33 @@
+package com.github.lombrozo.testnames;
+
+import java.nio.file.Path;
+import lombok.Data;
+
+@Data
+class JavaParserCase implements TestCase {
+
+    private final String className;
+    private final String name;
+    private final Path path;
+
+    JavaParserCase(final String className, final String name, final Path path) {
+        this.className = className;
+        this.name = name;
+        this.path = path;
+    }
+
+    @Override
+    public String className() {
+        return this.className;
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public Path path() {
+        return this.path;
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/JavaTestCode.java
+++ b/src/main/java/com/github/lombrozo/testnames/JavaTestCode.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public final class JavaTestCode implements Names {
+public final class JavaTestCode implements Cases {
     private final Path path;
 
     public JavaTestCode(final Path path) {
@@ -19,19 +19,22 @@ public final class JavaTestCode implements Names {
     }
 
     @Override
-    public Collection<String> names() {
+    public Collection<TestCase> all() {
         try {
             final CompilationUnit parse = StaticJavaParser.parse(this.path);
             final List<Node> childNodes = parse.getChildNodes();
-            final List<String> names = new ArrayList<>();
+            final List<TestCase> names = new ArrayList<>();
             for (final Node childNode : childNodes) {
                 if (childNode instanceof ClassOrInterfaceDeclaration) {
                     final ClassOrInterfaceDeclaration clazz = (ClassOrInterfaceDeclaration) childNode;
                     clazz.getMethods().forEach(m -> {
                         if (!m.isPrivate() && (
                             m.isAnnotationPresent("Test")
-                                || m.isAnnotationPresent("ParameterizedTest")))
-                            names.add(m.getNameAsString());
+                                || m.isAnnotationPresent("ParameterizedTest"))) {
+
+                            final String name = m.getNameAsString();
+                            names.add(new JavaParserCase(clazz.getNameAsString(), name, this.path));
+                        }
                     });
                 }
             }

--- a/src/main/java/com/github/lombrozo/testnames/Names.java
+++ b/src/main/java/com/github/lombrozo/testnames/Names.java
@@ -1,9 +1,0 @@
-package com.github.lombrozo.testnames;
-
-import java.util.Collection;
-
-@FunctionalInterface
-public interface Names {
-
-    Collection<String> names();
-}

--- a/src/main/java/com/github/lombrozo/testnames/NotCamelCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/NotCamelCase.java
@@ -1,22 +1,25 @@
 package com.github.lombrozo.testnames;
 
 public class NotCamelCase implements Rule {
-    final String test;
+    final TestCase test;
 
-    public NotCamelCase(final String test) {
+    public NotCamelCase(final TestCase test) {
         this.test = test;
     }
 
     @Override
     public void validate() throws WrongTestName {
-        if (notCamelCase()) {
-            throw new WrongTestName(test, "test has to be written by using Camel Case.");
+        if (this.notCamelCase()) {
+            throw new WrongTestName(
+                this.test,
+                "test has to be written by using Camel Case"
+            );
         }
     }
 
     private boolean notCamelCase() {
         int stack = 0;
-        for (final char c : test.toCharArray()) {
+        for (final char c : this.test.name().toCharArray()) {
             if (Character.isUpperCase(c) && stack == 0) {
                 return true;
             } else if (stack != 0) {

--- a/src/main/java/com/github/lombrozo/testnames/NotContainsTestWord.java
+++ b/src/main/java/com/github/lombrozo/testnames/NotContainsTestWord.java
@@ -2,20 +2,20 @@ package com.github.lombrozo.testnames;
 
 public class NotContainsTestWord implements Rule {
 
-    public NotContainsTestWord(final String test) {
+    final TestCase test;
+
+    public NotContainsTestWord(final TestCase test) {
         this.test = test;
     }
-
-    final String test;
 
     @Override
     public void validate() throws WrongTestName {
         if (containsTest()) {
-            throw new WrongTestName(test, "test name doesn't have to contain the word 'test'.");
+            throw new WrongTestName(test, "test name doesn't have to contain the word 'test'");
         }
     }
 
     private boolean containsTest() {
-        return test.matches(".*[Tt][Ee][Ss][Tt].*");
+        return test.name().matches(".*[Tt][Ee][Ss][Tt].*");
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/NotSpam.java
+++ b/src/main/java/com/github/lombrozo/testnames/NotSpam.java
@@ -1,9 +1,9 @@
 package com.github.lombrozo.testnames;
 
 public class NotSpam implements Rule {
-    private final String test;
+    private final TestCase test;
 
-    public NotSpam(final String test) {
+    public NotSpam(final TestCase test) {
         this.test = test;
     }
 
@@ -11,14 +11,14 @@ public class NotSpam implements Rule {
     public void validate() throws WrongTestName {
         if (!notSpam()) {
             throw new WrongTestName(test, "test name doesn't "
-                + "have to contain duplicated symbols.");
+                + "have to contain duplicated symbols");
         }
     }
 
     private boolean notSpam() {
         int stack = 0;
         char prev = '!';
-        for (final char c : test.toCharArray()) {
+        for (final char c : test.name().toCharArray()) {
             if (c == prev) {
                 stack++;
             } else {

--- a/src/main/java/com/github/lombrozo/testnames/NotUsesSpecialCharacters.java
+++ b/src/main/java/com/github/lombrozo/testnames/NotUsesSpecialCharacters.java
@@ -1,9 +1,9 @@
 package com.github.lombrozo.testnames;
 
 public class NotUsesSpecialCharacters implements Rule {
-    private final String test;
+    private final TestCase test;
 
-    public NotUsesSpecialCharacters(final String test) {
+    public NotUsesSpecialCharacters(final TestCase test) {
         this.test = test;
     }
 
@@ -11,11 +11,11 @@ public class NotUsesSpecialCharacters implements Rule {
     public void validate() throws WrongTestName {
         if (usesSpecialCharacters()) {
             throw new WrongTestName(test, "test name shouldn't contain special characters "
-                + "like '$' or '_'.");
+                + "like '$' or '_'");
         }
     }
 
     private boolean usesSpecialCharacters() {
-        return test.contains("$") || test.contains("_");
+        return test.name().contains("$") || test.name().contains("_");
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/PresentSimpleRule.java
+++ b/src/main/java/com/github/lombrozo/testnames/PresentSimpleRule.java
@@ -7,7 +7,7 @@ public final class PresentSimpleRule implements Rule {
 
     private final Collection<Rule> all;
 
-    public PresentSimpleRule(final String test) {
+    public PresentSimpleRule(final TestCase test) {
         this.all = Arrays.asList(
             new NotCamelCase(test),
             new NotContainsTestWord(test),

--- a/src/main/java/com/github/lombrozo/testnames/PresentTense.java
+++ b/src/main/java/com/github/lombrozo/testnames/PresentTense.java
@@ -1,21 +1,21 @@
 package com.github.lombrozo.testnames;
 
 public class PresentTense implements Rule{
-    private final String test;
+    private final TestCase test;
 
-    public PresentTense(final String test) {
+    public PresentTense(final TestCase test) {
         this.test = test;
     }
 
     @Override
     public void validate() throws WrongTestName {
         if(!presentTense()){
-            throw new WrongTestName(test, "the test name has to be written using present tense.");
+            throw new WrongTestName(test, "the test name has to be written using present tense");
         }
     }
 
     private boolean presentTense() {
-        final char[] chars = test.toCharArray();
+        final char[] chars = test.name().toCharArray();
         char prev = '!';
         for (final char c : chars) {
             if (Character.isUpperCase(c)) {

--- a/src/main/java/com/github/lombrozo/testnames/RuleForAllTests.java
+++ b/src/main/java/com/github/lombrozo/testnames/RuleForAllTests.java
@@ -4,17 +4,17 @@ import java.util.Collection;
 
 final class RuleForAllTests implements Rule {
 
-    private final Names tests;
+    private final Cases tests;
 
-    RuleForAllTests(final Names test) {
+    RuleForAllTests(final Cases test) {
         this.tests = test;
     }
 
     @Override
     public void validate() throws WrongTestName {
-        final Collection<String> names = this.tests.names();
-        for (final String test : names) {
-            new PresentSimpleRule(test).validate();
+        final Collection<TestCase> names = this.tests.all();
+        for (final TestCase test : names) {
+            new PresentSimpleRule(test.name()).validate();
         }
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/RuleForAllTests.java
+++ b/src/main/java/com/github/lombrozo/testnames/RuleForAllTests.java
@@ -14,7 +14,7 @@ final class RuleForAllTests implements Rule {
     public void validate() throws WrongTestName {
         final Collection<TestCase> names = this.tests.all();
         for (final TestCase test : names) {
-            new PresentSimpleRule(test.name()).validate();
+            new PresentSimpleRule(test).validate();
         }
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -1,0 +1,46 @@
+package com.github.lombrozo.testnames;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public interface TestCase {
+
+    String className();
+
+    String name();
+
+    Path path();
+
+
+    class FakeCase implements TestCase {
+
+        private final String className;
+        private final String name;
+        private final Path path;
+
+        FakeCase(final String name) {
+            this("FakeClass", name, Paths.get("."));
+        }
+
+        FakeCase(final String className, final String name, final Path path) {
+            this.className = className;
+            this.name = name;
+            this.path = path;
+        }
+
+        @Override
+        public String className() {
+            return className;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public Path path() {
+            return path;
+        }
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -2,6 +2,7 @@ package com.github.lombrozo.testnames;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import lombok.Data;
 
 public interface TestCase {
 
@@ -11,7 +12,7 @@ public interface TestCase {
 
     Path path();
 
-
+    @Data
     class FakeCase implements TestCase {
 
         private final String className;

--- a/src/main/java/com/github/lombrozo/testnames/WrongTestName.java
+++ b/src/main/java/com/github/lombrozo/testnames/WrongTestName.java
@@ -5,16 +5,25 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 public final class WrongTestName extends Exception {
-    public WrongTestName(final String test) {
-        super(String.format("Test name '%s' doesn't follow naming rules", test));
-    }
-
-    public WrongTestName(final String test, final String explanation) {
+    public WrongTestName(final TestCase test) {
         super(
             String.format(
-                "Test name '%s' doesn't follow naming rules, because %s",
-                test,
-                explanation
+                "Test name '%s#%s' doesn't follow naming rules, test path: %s",
+                test.className(),
+                test.name(),
+                test.path()
+            )
+        );
+    }
+
+    public WrongTestName(final TestCase test, final String explanation) {
+        super(
+            String.format(
+                "Test name '%s#%s' doesn't follow naming rules, because %s, test path: %s",
+                test.className(),
+                test.name(),
+                explanation,
+                test.path()
             )
         );
     }

--- a/src/test/java/com/github/lombrozo/testnames/JavaTestCodeTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/JavaTestCodeTest.java
@@ -17,10 +17,25 @@ class JavaTestCodeTest {
         final String java = "TestSimple.java";
         final Path path = temp.resolve(java);
         Files.write(path, new BytesOf(new ResourceOf(java)).asBytes());
-        final Names names = new JavaTestCode(path);
+        final Cases cases = new JavaTestCode(path);
         MatcherAssert.assertThat(
-            names.names(),
-            Matchers.containsInAnyOrder("creates", "removes", "updates")
+            cases.all(),
+            Matchers.containsInAnyOrder(
+                new JavaParserCase(
+                    "TestSimple",
+                    "creates",
+                    path
+                ), new JavaParserCase(
+                    "TestSimple",
+                    "removes",
+                    path
+                ),
+                new JavaParserCase(
+                    "TestSimple",
+                    "updates",
+                    path
+                )
+            )
         );
     }
 
@@ -29,10 +44,16 @@ class JavaTestCodeTest {
         final String java = "TestParameterized.java";
         final Path path = temp.resolve(java);
         Files.write(path, new BytesOf(new ResourceOf(java)).asBytes());
-        final Names names = new JavaTestCode(path);
+        final Cases cases = new JavaTestCode(path);
         MatcherAssert.assertThat(
-            names.names(),
-            Matchers.containsInAnyOrder("checksCases")
+            cases.all(),
+            Matchers.containsInAnyOrder(
+                new JavaParserCase(
+                    "TestParameterized",
+                    "checksCases",
+                    path
+                )
+            )
         );
     }
 
@@ -40,7 +61,7 @@ class JavaTestCodeTest {
     void throwsExceptionIfFileNotFound(@TempDir final Path temp) throws Exception {
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new JavaTestCode(temp.resolve("TestNotFound.java")).names()
+            () -> new JavaTestCode(temp.resolve("TestNotFound.java")).all()
         );
     }
 
@@ -50,8 +71,9 @@ class JavaTestCodeTest {
         Files.write(path, "Not Java".getBytes());
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new JavaTestCode(path).names()
+            () -> new JavaTestCode(path).all()
         );
     }
+
 
 }

--- a/src/test/java/com/github/lombrozo/testnames/RuleForAllTestsTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/RuleForAllTestsTest.java
@@ -9,7 +9,7 @@ class RuleForAllTestsTest {
     @Test
     void validatesAllWithoutExceptions() {
         try {
-            new RuleForAllTests(() -> Arrays.asList("removes", "creates")).validate();
+            new RuleForAllTests(Cases.correct()).validate();
         } catch (final WrongTestName ex) {
             Assertions.fail(ex);
         }
@@ -19,7 +19,7 @@ class RuleForAllTestsTest {
     void validatesAllWithExceptions() {
         Assertions.assertThrows(
             WrongTestName.class,
-            () -> new RuleForAllTests(() -> Arrays.asList("creates", "test")).validate()
+            () -> new RuleForAllTests(Cases.wrong()).validate()
         );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/RuleTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/RuleTest.java
@@ -42,7 +42,7 @@ public class RuleTest {
     })
     public void validatesCorrectly(String name, boolean expected) {
         try {
-            new PresentSimpleRule(name).validate();
+            new PresentSimpleRule(new TestCase.FakeCase(name)).validate();
             Assertions.assertTrue(expected);
         } catch (WrongTestName ex) {
             Assertions.assertFalse(expected);

--- a/src/test/java/com/github/lombrozo/testnames/WrongTestNameTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/WrongTestNameTest.java
@@ -11,8 +11,15 @@ class WrongTestNameTest {
     void createsUsingSingleParamConstructor() {
         final String name = UUID.randomUUID().toString();
         MatcherAssert.assertThat(
-            new WrongTestName(name).getMessage(),
-            Matchers.equalTo(String.format("Test name '%s' doesn't follow naming rules", name))
+            new WrongTestName(new TestCase.FakeCase(name)).getMessage(),
+            Matchers.equalTo(
+                String.format(
+                    "Test name '%s#%s' doesn't follow naming rules, test path: %s",
+                    "FakeClass",
+                    name,
+                    "."
+                )
+            )
         );
     }
 
@@ -21,12 +28,14 @@ class WrongTestNameTest {
         final String name = UUID.randomUUID().toString();
         final String reason = UUID.randomUUID().toString();
         MatcherAssert.assertThat(
-            new WrongTestName(name, reason).getMessage(),
+            new WrongTestName(new TestCase.FakeCase(name), reason).getMessage(),
             Matchers.equalTo(
                 String.format(
-                    "Test name '%s' doesn't follow naming rules, because %s",
+                    "Test name '%s#%s' doesn't follow naming rules, because %s, test path: %s",
+                    "FakeClass",
                     name,
-                    reason
+                    reason,
+                    "."
                 )
             )
         );
@@ -36,8 +45,8 @@ class WrongTestNameTest {
     void createsUsingSeveralExceptions() {
         MatcherAssert.assertThat(
             new WrongTestName(
-                new WrongTestName("test1"),
-                new WrongTestName("test2")
+                new WrongTestName(new TestCase.FakeCase("test1")),
+                new WrongTestName(new TestCase.FakeCase("test2"))
             ).getMessage(),
             Matchers.allOf(
                 Matchers.containsString("test1"),

--- a/src/test/resources/TestSimple.java
+++ b/src/test/resources/TestSimple.java
@@ -2,7 +2,7 @@ package com.github.lombrozo.testnames;
 
 import org.junit.jupiter.api.Test;
 
-class TestExample {
+class TestSimple {
     @Test
     void creates() {
     }


### PR DESCRIPTION
Add more informative messages for warnings:
```
[ERROR] Test name 'FtCachedTest#loadsTTTTontentOfCachedFile' doesn't follow naming rules, because test name doesn't have to contain duplicated symbols, test path: /Users/lombrozo/Workspace/EOlang/eo/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtCachedTest.java
[ERROR] Test name 'FtDefaultTest#loadsTESTContentOfNoCacheFile' doesn't follow naming rules, because test name doesn't have to contain the word 'test', test path: /Users/lombrozo/Workspace/EOlang/eo/eo-maven-plugin/src/test/java/org/eolang/maven/footprint/FtDefaultTest.java
```